### PR TITLE
Feature/testing precompile test function modifier

### DIFF
--- a/precompile/living-assets/src/lib.rs
+++ b/precompile/living-assets/src/lib.rs
@@ -49,7 +49,6 @@ where
 		handle.check_function_modifier(match selector {
 			Action::OwnerOfCollection => FunctionModifier::View,
 			Action::CreateCollection => FunctionModifier::NonPayable,
-			_ => FunctionModifier::NonPayable,
 		})?;
 
 		match selector {

--- a/precompile/living-assets/src/lib.rs
+++ b/precompile/living-assets/src/lib.rs
@@ -48,6 +48,7 @@ where
 
 		handle.check_function_modifier(match selector {
 			Action::OwnerOfCollection => FunctionModifier::View,
+			Action::CreateCollection => FunctionModifier::NonPayable,
 			_ => FunctionModifier::NonPayable,
 		})?;
 

--- a/precompile/living-assets/src/tests.rs
+++ b/precompile/living-assets/src/tests.rs
@@ -37,6 +37,16 @@ fn create_collection_on_mock_fail_with_other_error() {
 }
 
 #[test]
+fn create_collection_on_mock_with_nonzero_value_fails() {
+	define_precompile_mock!(Ok(()), Some(H160::zero()));
+
+	let input = "1eaf25160000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b7469c43535c826e29c30d25a9f3a035759cf132";
+	let mut handle = create_mock_handle(input, 0, 1);
+	let result = PrecompileMock::execute(&mut handle);
+	assert!(result.is_err());
+}
+
+#[test]
 fn create_collection_on_mock_fail_with_corruption_error() {
 	define_precompile_mock!(Err(DispatchError::Corruption), Some(H160::zero()));
 
@@ -50,6 +60,16 @@ fn create_collection_on_mock_fail_with_corruption_error() {
 			exit_status: ExitError::Other(sp_std::borrow::Cow::Borrowed("Corruption"))
 		}
 	);
+}
+
+#[test]
+fn owner_of_with_nonzero_transfer_should_fail() {
+	define_precompile_mock!(Ok(()), None);
+
+	let input = "fb34ae530000000000000000000000000000000000000000000000000000000000000000";
+	let mut handle = create_mock_handle(input, 0, 1);
+	let result = PrecompileMock::execute(&mut handle);
+	assert!(result.is_err());
 }
 
 #[test]

--- a/precompile/living-assets/src/tests.rs
+++ b/precompile/living-assets/src/tests.rs
@@ -15,7 +15,7 @@ fn create_collection_on_mock_succeed_should_succeed() {
 	define_precompile_mock!(Ok(()), Some(H160::zero()));
 
 	let input = "1eaf25160000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b7469c43535c826e29c30d25a9f3a035759cf132";
-	let mut handle = create_mock_handle(input, 0);
+	let mut handle = create_mock_handle(input, 0, 0);
 	let result = PrecompileMock::execute(&mut handle);
 	assert!(result.is_ok());
 }
@@ -25,7 +25,7 @@ fn create_collection_on_mock_fail_with_other_error() {
 	define_precompile_mock!(Err(DispatchError::Other("pizza error")), Some(H160::zero()));
 
 	let input = "1eaf25160000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b7469c43535c826e29c30d25a9f3a035759cf132";
-	let mut handle = create_mock_handle(input, 0);
+	let mut handle = create_mock_handle(input, 0, 0);
 	let result = PrecompileMock::execute(&mut handle);
 	assert!(result.is_err());
 	assert_eq!(
@@ -41,7 +41,7 @@ fn create_collection_on_mock_fail_with_corruption_error() {
 	define_precompile_mock!(Err(DispatchError::Corruption), Some(H160::zero()));
 
 	let input = "1eaf25160000000000000000000000000000000000000000000000000000000000000000000000000000000000000000b7469c43535c826e29c30d25a9f3a035759cf132";
-	let mut handle = create_mock_handle(input, 0);
+	let mut handle = create_mock_handle(input, 0, 0);
 	let result = PrecompileMock::execute(&mut handle);
 	assert!(result.is_err());
 	assert_eq!(
@@ -57,7 +57,7 @@ fn owner_of_on_no_owner_should_return_null() {
 	define_precompile_mock!(Ok(()), None);
 
 	let input = "fb34ae530000000000000000000000000000000000000000000000000000000000000000";
-	let mut handle = create_mock_handle(input, 0);
+	let mut handle = create_mock_handle(input, 0, 0);
 	let result = PrecompileMock::execute(&mut handle);
 	assert_eq!(result.unwrap().output, Vec::<u8>::new());
 }
@@ -67,7 +67,7 @@ fn owner_of_should_return_owner_of_mock() {
 	define_precompile_mock!(Ok(()), Some(H160::from_low_u64_be(0x1234)));
 
 	let input = "fb34ae530000000000000000000000000000000000000000000000000000000000000000";
-	let mut handle = create_mock_handle(input, 0);
+	let mut handle = create_mock_handle(input, 0, 0);
 	let result = PrecompileMock::execute(&mut handle);
 	assert!(result.is_ok());
 	assert_eq!(result.unwrap().output, H160::from_low_u64_be(0x1234).encode());
@@ -78,7 +78,7 @@ fn call_unexistent_selector_should_fail() {
 	define_precompile_mock!(Ok(()), Some(H160::from_low_u64_be(0x1234)));
 
 	let input = "fb24ae530000000000000000000000000000000000000000000000000000000000000000";
-	let mut handle = create_mock_handle(input, 0);
+	let mut handle = create_mock_handle(input, 0, 0);
 	let result = PrecompileMock::execute(&mut handle);
 	assert_eq!(
 		result.unwrap_err(),
@@ -146,19 +146,20 @@ mod helpers {
 	///
 	/// * `input` - The input data as a hexadecimal string.
 	/// * `cost` - A cost value as u64.
+	/// * `value` - The amount of coins transferred as u64.
 	///
 	/// # Example
 	///
 	/// ```
-	/// let handle = create_mock_handle("68656c6c6f", 0);
+	/// let handle = create_mock_handle("68656c6c6f", 0, 0);
 	/// ```
-	pub fn create_mock_handle(input: &str, cost: u64) -> MockHandle {
+	pub fn create_mock_handle(input: &str, cost: u64, value: u64) -> MockHandle {
 		let i: Vec<u8> = hex::decode(input).expect("todo");
 
 		let context: Context = Context {
 			address: Default::default(),
 			caller: Default::default(),
-			apparent_value: From::from(0),
+			apparent_value: From::from(value),
 		};
 
 		MockHandle::new(i, Some(cost), context)


### PR DESCRIPTION
Added tests that the methods implemented are non-payable, by trying to pass non-zero value as part of the transaction, which is exactly what check_function_modifier internally does.

Would be nice to add to the test that the received error is "function is not payable" 