### PR TITLE
PoC `AssetOwner` migration logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
 	"pallets/*",
 	"primitives",
 ]
+resolver = "2"
 
 [workspace.dependencies]
 parity-scale-codec = { version = "3.2.2", default-features = false, features = ["derive"] }

--- a/pallets/living-assets-ownership/Cargo.toml
+++ b/pallets/living-assets-ownership/Cargo.toml
@@ -35,7 +35,8 @@ default = ["std"]
 runtime-benchmarks = [
 	"frame-benchmarking/runtime-benchmarks",
 	"frame-system/runtime-benchmarks",
-	"frame-support/runtime-benchmarks"
+	"frame-support/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
 ]
 std = [
 	"parity-scale-codec/std",
@@ -51,5 +52,6 @@ std = [
 ]
 try-runtime = [
 	"frame-system/try-runtime",
-	"frame-support/try-runtime"
+	"frame-support/try-runtime",
+	"sp-runtime/try-runtime",
 ]

--- a/pallets/living-assets-ownership/src/lib.rs
+++ b/pallets/living-assets-ownership/src/lib.rs
@@ -7,7 +7,9 @@ pub use pallet::*;
 use parity_scale_codec::alloc::string::ToString;
 use sp_core::H160;
 use sp_std::vec::Vec;
+
 mod functions;
+pub mod migrations;
 pub mod traits;
 
 #[frame_support::pallet]

--- a/pallets/living-assets-ownership/src/migrations/mod.rs
+++ b/pallets/living-assets-ownership/src/migrations/mod.rs
@@ -1,0 +1,3 @@
+//! Migrations for the LivingAssetsOwnership pallet.
+
+pub mod v1;

--- a/pallets/living-assets-ownership/src/migrations/v1.rs
+++ b/pallets/living-assets-ownership/src/migrations/v1.rs
@@ -1,0 +1,121 @@
+use crate::{Config, Pallet};
+use frame_support::{
+	storage_alias,
+	traits::{Get, OnRuntimeUpgrade},
+};
+
+#[cfg(feature = "try-runtime")]
+use sp_std::vec::Vec;
+
+/// Collection of storage item formats from the previous storage version.
+mod old {
+	use frame_support::{pallet_prelude::OptionQuery, Blake2_128Concat};
+	use sp_core::U256;
+
+	use super::*;
+
+	/// V0 type for [`crate::Value`].
+	#[storage_alias]
+	pub(super) type AssetOwner<T: Config> = StorageMap<
+		Pallet<T>,
+		Blake2_128Concat,
+		U256,
+		<T as frame_system::Config>::AccountId,
+		OptionQuery,
+	>;
+}
+
+/// Unchecked version migration logic.
+pub mod version_unchecked {
+	use frame_support::{weights::Weight, StoragePrefixedMap};
+	use sp_io::{storage::clear_prefix, KillStorageResult};
+
+	use super::*;
+
+	/// Migrate from [`StorageVersion`] 0 to 1.
+	pub struct MigrateV0ToV1<T>(sp_std::marker::PhantomData<T>);
+
+	impl<T: Config> OnRuntimeUpgrade for MigrateV0ToV1<T> {
+		/// Return the existing `AssetOwner` storage item.
+		#[cfg(feature = "try-runtime")]
+		fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+			use parity_scale_codec::Encode;
+
+			// access the storage item
+			let old_keys = old::AssetOwner::<T>::iter_keys().collect::<Vec<_>>();
+
+			frame_support::log::debug!("old_keys: {:?}", old_keys);
+
+			// encode the storage item
+			Ok(old_keys.encode())
+		}
+
+		/// Migrate the [`old::AssetOwner`] storage item to the new format [`crate::AssetOwner`]
+		///
+		/// Since we lost the `collection_id` information, we can't migrate the storage items.
+		/// So we just purge all storage items.
+		///
+		/// This function is called during the runtime upgrade process.
+		fn on_runtime_upgrade() -> frame_support::weights::Weight {
+			let db_weight = <T as frame_system::Config>::DbWeight::get();
+
+			// simply purge all storage items
+			let mut weight_consumed = Weight::default();
+
+			// TODO: no limit is dangerous
+			match clear_prefix(&old::AssetOwner::<T>::final_prefix(), None) {
+				KillStorageResult::AllRemoved(all) => {
+					weight_consumed += db_weight.writes(all.into());
+				},
+				KillStorageResult::SomeRemaining(some) => {
+					weight_consumed += db_weight.writes(some.into());
+				},
+			}
+
+			weight_consumed
+		}
+
+		/// Post-upgrade migration step.
+		#[cfg(feature = "try-runtime")]
+		fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+			use frame_support::ensure;
+			use parity_scale_codec::Decode;
+
+			let old_keys = Vec::<sp_core::U256>::decode(&mut &state[..])
+				.map_err(|_| sp_runtime::TryRuntimeError::Other("Failed to decode old_keys"))?;
+
+			frame_support::log::debug!("old_keys: {:?}", old_keys);
+
+			// check the old storage items
+			for old_key in old_keys {
+				let old_asset_owner = old::AssetOwner::<T>::get(old_key);
+				ensure!(old_asset_owner.is_none(), "WARNING: old_asset_owner is not None");
+			}
+
+			Ok(())
+		}
+	}
+}
+
+// Public module containing *version checked* migration logic.
+//
+// This is the only module that should be exported from this module.
+//
+// TODO: we should use `frame_support::migrations::VersionedMigration` when the following PR is included in release.
+// https://github.com/paritytech/polkadot-sdk/pull/1503
+// pub mod versioned {
+// 	use super::*;
+
+// 	/// `version_unchecked::MigrateV0ToV1` wrapped in a
+// 	/// [`VersionedMigration`](frame_support::migrations::VersionedMigration), which ensures that:
+// 	/// - The migration only runs once when the on-chain storage version is 0
+// 	/// - The on-chain storage version is updated to `1` after the migration executes
+// 	/// - Reads/Writes from checking/settings the on-chain storage version are accounted for
+// 	pub type MigrateV0ToV1<T> = frame_support::migrations::VersionedRuntimeUpgrade<
+// 		0, // The migration will only execute when the on-chain storage version is 0
+// 		1, // The on-chain storage version will be set to 1 after the migration is complete
+// 		version_unchecked::MigrateV0ToV1<T>,
+// 		crate::pallet::Pallet<T>,
+// 		<T as frame_system::Config>::DbWeight,
+// 	>;
+// }

--- a/precompile/erc721/src/lib.rs
+++ b/precompile/erc721/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 use fp_evm::{Precompile, PrecompileHandle, PrecompileOutput};
-use frame_support::pallet_prelude::*;
 use pallet_living_assets_ownership::{address_to_collection_id, CollectionId};
 use precompile_utils::{
 	keccak256, revert, succeed, Address, Bytes, EvmDataWriter, EvmResult, FunctionModifier, LogExt,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -175,6 +175,8 @@ std = [
 	"bp-runtime/std",
 	"bridge-runtime-common/std",
 	"pallet-bridge-grandpa/std",
+	"hex/std",
+	"ownership-parachain-primitives/std",
 ]
 
 runtime-benchmarks = [

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -154,6 +154,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	(pallet_living_assets_ownership::migrations::v1::version_unchecked::MigrateV0ToV1<Runtime>,),
 >;
 
 pub type Precompiles = FrontierPrecompiles<Runtime>;
@@ -213,7 +214,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("laos-parachain"),
 	impl_name: create_runtime_str!("laos-parachain"),
 	authoring_version: 1,
-	spec_version: 6,
+	spec_version: 7,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
to test it locally:

```bash
./target/release/laos try-runtime \
--runtime ./target/release/wbuild/laos-runtime/laos_runtime.compact.compressed.wasm \
on-runtime-upgrade \
live --uri ws://localhost:9944
```

This assumes that you have a synced laos-ownership chain node at `9944` port locally. We can't currently use remote `wss://arrakis.gorengine.com:443` because no port is open for `RPC` connection and `try-runtime` requires `port` in the `--uri`